### PR TITLE
Tracking and Quote design on home page without functionality

### DIFF
--- a/DeliverySystem/package-lock.json
+++ b/DeliverySystem/package-lock.json
@@ -15,6 +15,7 @@
         "formik": "^2.4.6",
         "react": "^18.3.1",
         "react-dom": "^18.3.1",
+        "react-icons": "^5.3.0",
         "react-router-dom": "^6.26.2",
         "yup": "^1.4.0"
       },
@@ -3247,6 +3248,15 @@
       "version": "2.0.4",
       "resolved": "https://registry.npmjs.org/react-fast-compare/-/react-fast-compare-2.0.4.tgz",
       "integrity": "sha512-suNP+J1VU1MWFKcyt7RtjiSWUjvidmQSlqu+eHslq+342xCbGTYmC0mEhPCOHxlW0CywylOC1u2DFAT+bv4dBw=="
+    },
+    "node_modules/react-icons": {
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/react-icons/-/react-icons-5.3.0.tgz",
+      "integrity": "sha512-DnUk8aFbTyQPSkCfF8dbX6kQjXA9DktMeJqfjrg6cK9vwQVMxmcA3BfP4QoiztVmEHtwlTgLFsPuH2NskKT6eg==",
+      "license": "MIT",
+      "peerDependencies": {
+        "react": "*"
+      }
     },
     "node_modules/react-is": {
       "version": "18.3.1",

--- a/DeliverySystem/package.json
+++ b/DeliverySystem/package.json
@@ -17,6 +17,7 @@
     "formik": "^2.4.6",
     "react": "^18.3.1",
     "react-dom": "^18.3.1",
+    "react-icons": "^5.3.0",
     "react-router-dom": "^6.26.2",
     "yup": "^1.4.0"
   },

--- a/DeliverySystem/src/Components/pages/HomePage/HomePage.tsx
+++ b/DeliverySystem/src/Components/pages/HomePage/HomePage.tsx
@@ -1,12 +1,117 @@
 import { Grid2, Typography } from '@mui/material';
 import {useBodyBackground} from "../../../Hooks/useBodyBackground.ts";
 import {BACKGROUND_RIGHT, IMAGE3} from "../../../constants.ts";
+import TextField from '@mui/material/TextField';
+import Card from '@mui/material/Card';
+import CardContent from '@mui/material/CardContent';
+import Button from '@mui/material/Button';
+import ButtonGroup from '@mui/material/ButtonGroup';
+import { LuTruck } from "react-icons/lu";
+import { LuPackageSearch } from "react-icons/lu";
+import { useState } from 'react'; 
 
 export const HomePage = () => {
-    useBodyBackground({ backgroundImage: IMAGE3, backgroundPosition: BACKGROUND_RIGHT, backgroundSize: 'cover'});
+  useBodyBackground({ backgroundImage: IMAGE3, backgroundPosition: BACKGROUND_RIGHT, backgroundSize: 'cover' });
+
+  // Single state to toggle between track and quote display
+  const [isQuoteDisplay, setIsQuoteDisplay] = useState(false);
+
+  const handleQuoteClick = () => {
+    setIsQuoteDisplay(true);  // Show the quote section
+  };
+
+  const handleTrackClick = () => {
+    setIsQuoteDisplay(false);  // Show the track section
+  };
+
+  return (
+    <>
+      <p style={{ margin: '20px', color: 'white', fontSize: '30px' }}>Global Reach,<br />Reliable Deliveries.</p>
+      {/* Conditionally render trackDisplay or quoteDisplay based on state */}
+      {isQuoteDisplay ? quoteDisplay(handleTrackClick) : trackDisplay(handleQuoteClick)}
+    </>
+  );
+};
+
+const trackDisplay = (handleQuoteClick: () => void) => {
   return (
     <Grid2 mt={1}>
-      <Typography p={10} textAlign={'center'} color={'white'}>This is a Homepage</Typography>
+      <Card sx={{ maxWidth: 275 }}>
+        <CardContent>
+          <Grid2 mt={1}>
+            <Card sx={{ maxWidth: 220 }}>
+              <CardContent>
+                <ButtonGroup variant="outlined" aria-label="Basic button group" sx={{ width: '190px' }}>
+                  <Button variant="contained" sx={{ width: '50%', backgroundColor: 'black', color: 'white', '&:hover': { backgroundColor: 'gray' } }}>
+                    <span style={{ display: 'flex', alignItems: 'center' }}>
+                      <LuPackageSearch size={24} style={{ marginRight: '8px' }} />
+                      Track
+                    </span>
+                  </Button>
+                  {/* Trigger switching to quote display */}
+                  <Button sx={{ width: '50%', color: 'black', borderColor: 'black', '&:hover': { borderColor: 'black', backgroundColor: 'rgba(0, 0, 0, 0.04)' } }} onClick={handleQuoteClick}>
+                    <span style={{ display: 'flex', alignItems: 'center' }}>
+                      <LuTruck size={24} style={{ marginRight: '8px' }} />
+                      Quote
+                    </span>
+                  </Button>
+                </ButtonGroup>
+              </CardContent>
+            </Card>
+          </Grid2>
+          <Grid2 mt={1}>
+            <TextField id="outlined-basic" label="Tracking Number" variant="outlined" />
+          </Grid2>
+          <Grid2 mt={1}>
+            <Button variant="contained" sx={{ width: '220px', backgroundColor: 'black', color: 'white', '&:hover': { backgroundColor: 'gray' } }}>
+              Track Package
+            </Button>
+          </Grid2>
+        </CardContent>
+      </Card>
     </Grid2>
   );
-}
+};
+
+const quoteDisplay = (handleTrackClick: () => void) => {
+  return (
+    <Grid2 mt={1}>
+      <Card sx={{ maxWidth: 275 }}>
+        <CardContent>
+          <Grid2 mt={1}>
+            <Card sx={{ maxWidth: 220 }}>
+              <CardContent>
+                <ButtonGroup variant="outlined" aria-label="Basic button group" sx={{ width: '190px' }}>
+                  {/* Trigger switching to track display */}
+                  <Button sx={{ width: '50%', color: 'black', borderColor: 'black', '&:hover': { borderColor: 'black', backgroundColor: 'rgba(0, 0, 0, 0.04)' } }} onClick={handleTrackClick}>
+                    <span style={{ display: 'flex', alignItems: 'center' }}>
+                      <LuPackageSearch size={24} style={{ marginRight: '8px' }} />
+                      Track
+                    </span>
+                  </Button>
+                  <Button variant="contained" sx={{ width: '50%', backgroundColor: 'black', color: 'white', '&:hover': { backgroundColor: 'gray' } }}>
+                    <span style={{ display: 'flex', alignItems: 'center' }}>
+                      <LuTruck size={24} style={{ marginRight: '8px' }} />
+                      Quote
+                    </span>
+                  </Button>
+                </ButtonGroup>
+              </CardContent>
+            </Card>
+          </Grid2>
+          <Grid2 mt={1}>
+            <TextField id="outlined-basic" label="Origin" variant="outlined" />
+          </Grid2>
+          <Grid2 mt={1}>
+            <TextField id="outlined-basic" label="Destination" variant="outlined" />
+          </Grid2>
+          <Grid2 mt={1}>
+            <Button variant="contained" sx={{ width: '220px', backgroundColor: 'black', color: 'white', '&:hover': { backgroundColor: 'gray' } }}>
+              Get Quote
+            </Button>
+          </Grid2>
+        </CardContent>
+      </Card>
+    </Grid2>
+  );
+};


### PR DESCRIPTION
I put the Tracking and Quote design on the home page without its functionality. I used usestate to make it dynamic when pressing the button track and quote so that the menu switches. I will further modify the design as needed and I will also implement the functionality soon.